### PR TITLE
Disable middleware to prevent duplicate lifecycle execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-favicons",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "An all-in-one favicon and PWA assets generator for Astro projects. It automates the creation of favicons, manifest, and supports hot reloading for efficient development. Powered by `astro-capo`, it keeps your ﹤𝚑𝚎𝚊𝚍﹥ content well-organized and tidy.",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ export interface Options extends FaviconOptions {
    * @default config.compressHTML `true`
    */
   withCapo?: boolean;
+  /**
+   * Disable middleware from executing request lifecycle
+   * @default true
+   */
+  addMiddleware?: boolean;
 }
 
 export default function createIntegration(options?: Options): AstroIntegration {
@@ -38,6 +43,8 @@ export default function createIntegration(options?: Options): AstroIntegration {
         addMiddleware,
       }) => {
         opts.withCapo = opts.withCapo ?? config.compressHTML;
+        opts.addMiddleware = opts.addMiddleware ?? true;
+
         if (cmd === "build" || cmd === "dev") {
           if (!isRestart) {
             logger.info(`Processing source...`);
@@ -48,10 +55,13 @@ export default function createIntegration(options?: Options): AstroIntegration {
             },
           });
         }
-        addMiddleware({
-          entrypoint: `${name}/middleware`,
-          order: "pre",
-        });
+
+        if (opts.addMiddleware) {
+          addMiddleware({
+            entrypoint: `${name}/middleware`,
+            order: "pre",
+          });
+        }
       },
     },
   };


### PR DESCRIPTION
Currently, astro-favicons middleware executes on all requests, causing request lifecycle methods to run twice. This PR adds an option to disable the middleware, allowing favicons to be manually included only where needed through the use of localizedHTML export and Fragment.