### PR TITLE
fix: remove base prefix from emitted assets to prevent double base-path

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,7 @@ import type { Plugin, ResolvedConfig } from "vite";
 import type { Options } from ".";
 import { name } from "./config/packge";
 import { fetch } from "./core";
-import { getInput, normalizePath, mime } from "./helpers";
+import { getInput, mime } from "./helpers";
 import { formatTime } from "./utils/timer";
 import { styler as $s } from "./utils/styler";
 
@@ -26,7 +26,6 @@ export async function handleAssets(
   const processedTime = performance.now() - startAt;
 
   const { isRestart, logger } = params;
-  let base = normalizePath(opts.output?.assetsPrefix);
   //
   logger.info(
     `${files.length} file(s), ${images.length} image(s)` +
@@ -62,7 +61,7 @@ export async function handleAssets(
             images.find((img) => img.name === fileName) ||
             files.find((file) => file.name === fileName);
 
-          if (resource && req.url?.startsWith(`/${base}${resource?.name}`)) {
+          if (resource && req.url?.startsWith(`/${resource?.name}`)) {
             const mimeType = mime(fileName);
             res.setHeader("Content-Type", mimeType);
             res.setHeader("Cache-Control", "no-cache");
@@ -87,7 +86,7 @@ export async function handleAssets(
         }) => {
           const fileId = this.emitFile({
             type: "asset",
-            fileName: base + file.name,
+            fileName: file.name,
             source: file.contents,
           });
         };


### PR DESCRIPTION
Emitted favicons and manifest file URLs can end up with a double base-path, e.g.: `/base-path/base-path/favicon-192x192.png` when specifying `assetsPrefix`.

This happens because the integration manually prepends `assetsPrefix` to emitted assets, and Astro automatically applies its `base` config during build.

### Solution

- Removed the manual base prefix when emitting assets in `handleAssets`.
- Updated dev middleware to serve assets correctly without relying
  on the base prefix.
- Keeps all other integration behaviour unchanged so retains adding `assetsPrefix` to paths to output files.

### Testing

- Verified in `astro dev` that favicons load correctly using forked repo.
- Verified in `astro build` that generated assets are under the correct
  base path without duplication
- Verified on a GitHub Pages deployment that asset paths and their references match

---

Fixes #70