### PR TITLE
fix: avoid Cloudflare SSR prebundle breakage for `astro-favicons/middleware`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type { AstroIntegration } from "astro";
+import { fileURLToPath } from "node:url";
 import type { FaviconOptions, Input } from "./types";
 import { defaults } from "./config/defaults";
 import { handleAssets } from "./plugin";
@@ -25,6 +26,7 @@ export interface Options extends FaviconOptions {
 
 export default function createIntegration(options?: Options): AstroIntegration {
   const opts = { ...defaults, ...options };
+  const middlewareEntry = fileURLToPath(new URL("./middleware.mjs", import.meta.url));
 
   return {
     name,
@@ -45,6 +47,16 @@ export default function createIntegration(options?: Options): AstroIntegration {
           updateConfig({
             vite: {
               plugins: [await handleAssets(opts, { isRestart, logger })],
+              resolve: {
+                // Cloudflare's workerd dev pipeline can prebundle bare package
+                // subpath imports before the virtual module is registered.
+                alias: {
+                  [`${name}/middleware`]: middlewareEntry,
+                },
+              },
+              ssr: {
+                noExternal: [name, `${name}/middleware`],
+              },
             },
           });
         }


### PR DESCRIPTION
This fixes a Cloudflare compatibility issue where `astro-favicons/middleware` can be prebundled
  before `virtual:astro-favicons` is available.

  In affected setups, `astro dev` can fail with errors like:

  ```txt
  The file does not exist at ".../.vite/deps_ssr/astro-favicons_middleware.js"
  ```

  This patch:

  - aliases astro-favicons/middleware to the real middleware entry file
  - adds astro-favicons and astro-favicons/middleware to ssr.noExternal

  That keeps the middleware on the Vite/Astro pipeline and avoids the broken Cloudflare SSR
  prebundle path.